### PR TITLE
Add option for pre 5.3 server authentication

### DIFF
--- a/Classes/Data Model/Server.swift
+++ b/Classes/Data Model/Server.swift
@@ -27,7 +27,7 @@ final class Server {
     static let testServerId = Int64.max
     static var testServer: Server {
         // Return model directly rather than storing in the database
-        let testServer = Server(serverId: self.testServerId, type: .subsonic, url: "https://isubapp.com:9002", username: "isub-guest", basicAuth: false)
+        let testServer = Server(serverId: self.testServerId, type: .subsonic, url: "https://isubapp.com:9002", username: "isub-guest", basicAuth: false, legacyAuth: false)
         testServer.password = "1sub1snumb3r0n3"
         return testServer
     }
@@ -39,6 +39,7 @@ final class Server {
     var url: String
     var username: String
     var basicAuth: Bool
+    var legacyAuth: Bool
     
     fileprivate var passwordKey: String { return "\(serverId) - \(username)" }
     var password: String? {
@@ -54,12 +55,13 @@ final class Server {
         }
     }
     
-    init(serverId: Int64, type: ServerType, url: String, username: String, basicAuth: Bool, repository: ServerRepository = ServerRepository.si) {
+    init(serverId: Int64, type: ServerType, url: String, username: String, basicAuth: Bool, legacyAuth: Bool, repository: ServerRepository = ServerRepository.si) {
         self.serverId = serverId
         self.type = type
         self.url = url
         self.username = username
         self.basicAuth = basicAuth
         self.repository = repository
+        self.legacyAuth = legacyAuth
     }
 }

--- a/Classes/Data Model/ServerRepository.swift
+++ b/Classes/Data Model/ServerRepository.swift
@@ -51,13 +51,13 @@ struct ServerRepository: ItemRepository {
     }
     
     // Save new server
-    func server(type: ServerType, url: String, username: String, password: String, basicAuth: Bool) -> Server? {
+    func server(type: ServerType, url: String, username: String, password: String, basicAuth: Bool, legacyAuth: Bool) -> Server? {
         var success = true
         var serverId: Int64 = -1
         Database.si.write.inDatabase { db in
             do {
-                let query = "INSERT INTO servers VALUES (?, ?, ?, ?, ?)"
-                try db.executeUpdate(query, NSNull(), type.rawValue, url, username, basicAuth)
+                let query = "INSERT INTO servers VALUES (?, ?, ?, ?, ?, ?)"
+                try db.executeUpdate(query, NSNull(), type.rawValue, url, username, basicAuth, legacyAuth)
                 serverId = db.lastInsertRowId()
             } catch {
                 printError(error)
@@ -66,7 +66,7 @@ struct ServerRepository: ItemRepository {
         }
         
         if success && serverId >= 0 {
-            let server = Server(serverId: serverId, type: type, url: url, username: username, basicAuth: basicAuth)
+            let server = Server(serverId: serverId, type: type, url: url, username: username, basicAuth: basicAuth, legacyAuth: legacyAuth)
             server.password = password
             return server
         }
@@ -81,9 +81,10 @@ extension Server: PersistedItem {
         let url        = result.string(forColumnIndex: 2) ?? ""
         let username   = result.string(forColumnIndex: 3) ?? ""
         let basicAuth  = result.bool(forColumnIndex: 4)
+        let legacyAuth = result.bool(forColumnIndex: 5)
         let repository = repository as! ServerRepository
         
-        self.init(serverId: serverId, type: type, url: url, username: username, basicAuth: basicAuth, repository: repository)
+        self.init(serverId: serverId, type: type, url: url, username: username, basicAuth: basicAuth, legacyAuth: legacyAuth, repository: repository)
     }
     
     class func item(itemId: Int64, serverId: Int64, repository: ItemRepository = ServerRepository.si) -> Item? {

--- a/Classes/Extensions/NSError.swift
+++ b/Classes/Extensions/NSError.swift
@@ -19,6 +19,7 @@ enum iSubErrorCode: Int {
     case subsonicTrialExpired = 6
     case requiresBasicAuth = 7
     case serverNotInDb = 8
+    case tokenAuthNotSupported = 9
     
     var description: String {
         switch self {
@@ -30,6 +31,7 @@ enum iSubErrorCode: Int {
         case .subsonicTrialExpired: return "Subsonic API Trial Expired"
         case .requiresBasicAuth: return "Requires HTTP Basic Authentication"
         case .serverNotInDb: return "The server does not exist in the database"
+        case .tokenAuthNotSupported: return "Server does not support token authentication"
         }
     }
 }

--- a/Classes/Server Loading/SubsonicURLRequest.swift
+++ b/Classes/Server Loading/SubsonicURLRequest.swift
@@ -82,26 +82,39 @@ extension URLRequest {
                       parameters: parameters,
                       fragment: fragment,
                       byteOffset: byteOffset,
-                      basicAuth: server.basicAuth)
+                      basicAuth: server.basicAuth,
+                      legacyAuth: server.legacyAuth)
         } else {
              return nil
         }
     }
     
-    init(subsonicAction: SubsonicURLAction, baseUrl: String, username: String, password: String, parameters: [String: Any]? = nil, fragment: String? = nil, byteOffset: Int = 0, basicAuth: Bool = false) {
+    init(subsonicAction: SubsonicURLAction, baseUrl: String, username: String, password: String, parameters: [String: Any]? = nil, fragment: String? = nil, byteOffset: Int = 0, basicAuth: Bool = false, legacyAuth: Bool = false) {
         
         var urlString = "\(baseUrl)/rest/\(subsonicAction.rawValue).\(subsonicAction.urlExtension)"
         
-        // Generate a 32 character random salt
-        // Then use the Subsonic required md5(password + salt) function to generate the token.
-        let salt = String.random(32)
-        let token = (password + salt).md5.lowercased()
-        
-        // Only support Subsonic version 5.3 and later
-        let version = "1.13.0"
-        
+        var parametersString = "?c=iSub"//&v=\(version)//&u=\(username)&p=\(encpass)" //"&s=\(salt)"
+        if !legacyAuth {
+            // Generate a 32 character random salt
+            // Then use the Subsonic required md5(password + salt) function to generate the token.
+            let salt = String.random(32)
+            let token = (password + salt).md5.lowercased()
+            
+            // Supports Subsonic version 5.3 and later
+            let version = "1.13.0"
+            parametersString += "&v=\(version)//&u=\(username)&t=\(token)&s=\(salt)"
+        } else {
+            var encpass = "enc:"
+            for scalar in password.unicodeScalars {
+                encpass += String(scalar.value, radix: 16)
+            }
+            // For Subsonic version prior to 5.3 or other vendors like Ampache
+            let version = "1.11"
+            parametersString += "&v=\(version)//&u=\(username)&p=\(encpass)"
+        }
+
+            
         // Setup the parameters
-        var parametersString = "?c=iSub&v=\(version)&u=\(username)&t=\(token)&s=\(salt)"
         if let parameters = parameters {
             for (key, value) in parameters {
                 if let value = value as? [Any] {

--- a/Classes/Server Loading/SubsonicURLRequest.swift
+++ b/Classes/Server Loading/SubsonicURLRequest.swift
@@ -93,7 +93,7 @@ extension URLRequest {
         
         var urlString = "\(baseUrl)/rest/\(subsonicAction.rawValue).\(subsonicAction.urlExtension)"
         
-        var parametersString = "?c=iSub"//&v=\(version)//&u=\(username)&p=\(encpass)" //"&s=\(salt)"
+        var parametersString = "?c=iSub"
         if !legacyAuth {
             // Generate a 32 character random salt
             // Then use the Subsonic required md5(password + salt) function to generate the token.
@@ -102,7 +102,7 @@ extension URLRequest {
             
             // Supports Subsonic version 5.3 and later
             let version = "1.13.0"
-            parametersString += "&v=\(version)//&u=\(username)&t=\(token)&s=\(salt)"
+            parametersString += "&v=\(version)&u=\(username)&t=\(token)&s=\(salt)"
         } else {
             var encpass = "enc:"
             for scalar in password.unicodeScalars {
@@ -110,7 +110,7 @@ extension URLRequest {
             }
             // For Subsonic version prior to 5.3 or other vendors like Ampache
             let version = "1.11"
-            parametersString += "&v=\(version)//&u=\(username)&p=\(encpass)"
+            parametersString += "&v=\(version)&u=\(username)&p=\(encpass)"
         }
 
             

--- a/Classes/Singletons/Database.swift
+++ b/Classes/Singletons/Database.swift
@@ -169,6 +169,9 @@ final class Database {
             if !db.columnExists("basicAuth", inTableWithName: "servers") {
                 try? db.executeUpdate("ALTER TABLE servers ADD COLUMN basicAuth INTEGER")
             }
+            if !db.columnExists("legacyAuth", inTableWithName: "servers") {
+                try? db.executeUpdate("ALTER TABLE servers ADD COLUMN legacyAuth INTEGER")
+            }
         }
         
         // Create the default playlist tables

--- a/Classes/UI/Specific/SubsonicServerEditViewController.swift
+++ b/Classes/UI/Specific/SubsonicServerEditViewController.swift
@@ -27,6 +27,7 @@ class SubsonicServerEditViewController: UIViewController, UITextFieldDelegate {
     @IBOutlet weak var urlField: UITextField!
     @IBOutlet weak var usernameField: UITextField!
     @IBOutlet weak var passwordField: UITextField!
+    @IBOutlet weak var legacyAuthField: UISwitch!
     @IBOutlet weak var cancelButton: UIButton!
     @IBOutlet weak var saveButton: UIButton!
     
@@ -148,7 +149,7 @@ class SubsonicServerEditViewController: UIViewController, UITextFieldDelegate {
         }
         
         LoadingScreen.show(withMessage: "Checking Server")
-        statusLoader = StatusLoader(url: urlField.text!, username: usernameField.text!, password: passwordField.text!)
+        statusLoader = StatusLoader(url: urlField.text!, username: usernameField.text!, password: passwordField.text!, legacyAuth: legacyAuthField.isOn)
         statusLoader!.completionHandler = loadingCompletionHandler
         statusLoader!.start()
     }
@@ -169,7 +170,7 @@ class SubsonicServerEditViewController: UIViewController, UITextFieldDelegate {
                 server.replace()
             } else {
                 // Create new server
-                server = ServerRepository.si.server(type: .subsonic, url: statusLoader.url, username: statusLoader.username, password: statusLoader.password, basicAuth: statusLoader.basicAuth)
+                server = ServerRepository.si.server(type: .subsonic, url: statusLoader.url, username: statusLoader.username, password: statusLoader.password, basicAuth: statusLoader.basicAuth, legacyAuth: statusLoader.legacyAuth)
             }
             
             delegate?.serverEdited(server!)
@@ -183,7 +184,7 @@ class SubsonicServerEditViewController: UIViewController, UITextFieldDelegate {
                 }
                 
                 // Try again with basic auth (or without if the server already had it)
-                self.statusLoader = StatusLoader(url: urlField.text!, username: usernameField.text!, password: passwordField.text!, basicAuth: basicAuth)
+                self.statusLoader = StatusLoader(url: urlField.text!, username: usernameField.text!, password: passwordField.text!, legacyAuth: false, basicAuth: basicAuth)
                 self.statusLoader!.completionHandler = loadingCompletionHandler
                 self.statusLoader!.start()
                 retriedStatusLoader = true

--- a/Classes/en.lproj/SubsonicServerEditViewController.xib
+++ b/Classes/en.lproj/SubsonicServerEditViewController.xib
@@ -1,16 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
+    <customFonts key="customFonts">
+        <array key="Helvetica.ttc">
+            <string>Helvetica</string>
+            <string>Helvetica-Bold</string>
+        </array>
+    </customFonts>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SubsonicServerEditViewController">
             <connections>
                 <outlet property="cancelButton" destination="17" id="18"/>
+                <outlet property="legacyAuthField" destination="ces-hD-MAe" id="ug0-pO-Dd5"/>
                 <outlet property="passwordField" destination="5" id="10"/>
                 <outlet property="saveButton" destination="7" id="11"/>
                 <outlet property="urlField" destination="6" id="8"/>
@@ -54,29 +62,6 @@
                         <outlet property="delegate" destination="-1" id="16"/>
                     </connections>
                 </textField>
-                <button opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="7">
-                    <rect key="frame" x="200" y="247" width="75" height="33"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
-                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
-                    <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="18"/>
-                    <state key="normal" title="Save">
-                        <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    </state>
-                    <connections>
-                        <action selector="saveButtonPressed:" destination="-1" eventType="touchUpInside" id="12"/>
-                    </connections>
-                </button>
-                <button opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="17">
-                    <rect key="frame" x="104" y="247" width="75" height="33"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
-                    <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="18"/>
-                    <state key="normal" title="Cancel">
-                        <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    </state>
-                    <connections>
-                        <action selector="cancelButtonPressed:" destination="-1" eventType="touchUpInside" id="19"/>
-                    </connections>
-                </button>
                 <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" misplaced="YES" text="http://myserver.subsonic.org" lineBreakMode="tailTruncation" minimumFontSize="10" id="20">
                     <rect key="frame" x="49" y="27" width="235" height="21"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
@@ -98,6 +83,40 @@
                     <color key="textColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
+                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" id="ces-hD-MAe">
+                    <rect key="frame" x="49" y="267" width="49" height="31"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                </switch>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="legacy authentication" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="fvn-fA-kSS">
+                    <rect key="frame" x="49" y="240" width="164" height="21"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <color key="textColor" red="0.51251485233479832" green="0.51251485233479832" blue="0.51251485233479832" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <button opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="7">
+                    <rect key="frame" x="171" y="316" width="75" height="33"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
+                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                    <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="18"/>
+                    <state key="normal" title="Save">
+                        <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </state>
+                    <connections>
+                        <action selector="saveButtonPressed:" destination="-1" eventType="touchUpInside" id="12"/>
+                    </connections>
+                </button>
+                <button opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="17">
+                    <rect key="frame" x="75" y="316" width="75" height="33"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
+                    <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="18"/>
+                    <state key="normal" title="Cancel">
+                        <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </state>
+                    <connections>
+                        <action selector="cancelButtonPressed:" destination="-1" eventType="touchUpInside" id="19"/>
+                    </connections>
+                </button>
             </subviews>
             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <simulatedStatusBarMetrics key="simulatedStatusBarMetrics" statusBarStyle="blackOpaque"/>
@@ -107,9 +126,4 @@
     <resources>
         <image name="settings-page.png" width="320" height="460"/>
     </resources>
-    <simulatedMetricsContainer key="defaultSimulatedMetrics">
-        <simulatedStatusBarMetrics key="statusBar"/>
-        <simulatedOrientationMetrics key="orientation"/>
-        <simulatedScreenMetrics key="destination" type="retina4_7.fullscreen"/>
-    </simulatedMetricsContainer>
 </document>

--- a/iSub.xcodeproj/project.pbxproj
+++ b/iSub.xcodeproj/project.pbxproj
@@ -1676,7 +1676,6 @@
 				ORGANIZATIONNAME = "Ben Baron";
 				TargetAttributes = {
 					53BC269F139AF0DD00A825F1 = {
-						DevelopmentTeam = 8Z527XYLA9;
 						LastSwiftMigration = 0900;
 						ProvisioningStyle = Automatic;
 					};
@@ -2165,7 +2164,7 @@
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				DEVELOPMENT_TEAM = 8Z527XYLA9;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2197,7 +2196,7 @@
 				);
 				OTHER_SWIFT_FLAGS = "-D BetaTarget $(inherited)";
 				PRECOMPS_INCLUDE_HEADERS_FROM_BUILT_PRODUCTS_DIR = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = net.lannysport.isub;
+				PRODUCT_BUNDLE_IDENTIFIER = com.einsteinx2.isubbetarewrite;
 				PRODUCT_NAME = "iSub Beta";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 4.0;
@@ -2216,7 +2215,7 @@
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				DEVELOPMENT_TEAM = 8Z527XYLA9;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2248,7 +2247,7 @@
 				);
 				OTHER_SWIFT_FLAGS = "-D BetaTarget $(inherited)";
 				PRECOMPS_INCLUDE_HEADERS_FROM_BUILT_PRODUCTS_DIR = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = net.lannysport.isub;
+				PRODUCT_BUNDLE_IDENTIFIER = com.einsteinx2.isubbetarewrite;
 				PRODUCT_NAME = "iSub Beta";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 4.0;
@@ -2267,7 +2266,7 @@
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				DEVELOPMENT_TEAM = 8Z527XYLA9;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2297,7 +2296,7 @@
 				);
 				OTHER_SWIFT_FLAGS = "-D BetaTarget $(inherited)";
 				PRECOMPS_INCLUDE_HEADERS_FROM_BUILT_PRODUCTS_DIR = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = net.lannysport.isub;
+				PRODUCT_BUNDLE_IDENTIFIER = com.einsteinx2.isubbetarewrite;
 				PRODUCT_NAME = "iSub Beta";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 4.0;

--- a/iSub.xcodeproj/project.pbxproj
+++ b/iSub.xcodeproj/project.pbxproj
@@ -7,9 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		40F3F5081FD3CAA700B467BB /* SimilarSongsLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F3F5071FD3CAA700B467BB /* SimilarSongsLoader.swift */; };
-		40F3F5061FD3C03100B467BB /* AlbumListLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F3F5051FD3C03100B467BB /* AlbumListLoader.swift */; };
 		40B3FCC11FCBCE530085BEBA /* CreatePlaylistLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B3FCC01FCBCE530085BEBA /* CreatePlaylistLoader.swift */; };
+		40F3F5061FD3C03100B467BB /* AlbumListLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F3F5051FD3C03100B467BB /* AlbumListLoader.swift */; };
+		40F3F5081FD3CAA700B467BB /* SimilarSongsLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F3F5071FD3CAA700B467BB /* SimilarSongsLoader.swift */; };
 		5301F5CF1A4938F300EEB25D /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5301F5CC1A4938F300EEB25D /* Images.xcassets */; };
 		5306B6ED1FC1F2D000369EEF /* SubsonicItemParsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5306B6EC1FC1F2D000369EEF /* SubsonicItemParsing.swift */; };
 		5306B6EF1FC2129C00369EEF /* HTMLEntities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5306B6EE1FC2129B00369EEF /* HTMLEntities.framework */; };
@@ -332,8 +332,8 @@
 		53FE31311F07C594003AA6A7 /* JGSwitchTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53FE312B1F07C594003AA6A7 /* JGSwitchTableCell.swift */; };
 		53FE31321F07C594003AA6A7 /* JGTextTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53FE312C1F07C594003AA6A7 /* JGTextTableCell.swift */; };
 		7D0032151FD1988A009EAAFE /* SearchLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0032141FD1988A009EAAFE /* SearchLoader.swift */; };
-		7D6B0F561FCE2F0600BC4050 /* UpdatePlaylistLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6B0F551FCE2F0600BC4050 /* UpdatePlaylistLoader.swift */; };
 		7D0032171FD2158E009EAAFE /* RandomSongsLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0032161FD2158E009EAAFE /* RandomSongsLoader.swift */; };
+		7D6B0F561FCE2F0600BC4050 /* UpdatePlaylistLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6B0F551FCE2F0600BC4050 /* UpdatePlaylistLoader.swift */; };
 		D09496D41C6058BC00781B51 /* (null) in Resources */ = {isa = PBXBuildFile; };
 		D09496D91C6058BC00781B51 /* (null) in Resources */ = {isa = PBXBuildFile; };
 		D09496DE1C6058BC00781B51 /* (null) in Resources */ = {isa = PBXBuildFile; };
@@ -343,9 +343,9 @@
 		1D30AB110D05D00D00671497 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		1DF5F4DF0D08C38300B7A737 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		2892E40F0DC94CBA00A64D0F /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
-		40F3F5071FD3CAA700B467BB /* SimilarSongsLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimilarSongsLoader.swift; sourceTree = "<group>"; };
-		40F3F5051FD3C03100B467BB /* AlbumListLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumListLoader.swift; sourceTree = "<group>"; };
 		40B3FCC01FCBCE530085BEBA /* CreatePlaylistLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePlaylistLoader.swift; sourceTree = "<group>"; };
+		40F3F5051FD3C03100B467BB /* AlbumListLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumListLoader.swift; sourceTree = "<group>"; };
+		40F3F5071FD3CAA700B467BB /* SimilarSongsLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimilarSongsLoader.swift; sourceTree = "<group>"; };
 		5301F5CC1A4938F300EEB25D /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = Images/Images.xcassets; sourceTree = "<group>"; };
 		53030314116ADF8B00B0AF5D /* reload-table.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "reload-table.png"; path = "Images/Other/reload-table.png"; sourceTree = "<group>"; };
 		5305C2051157F4F800BC78F0 /* Default.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = Default.png; path = Images/Other/Default.png; sourceTree = "<group>"; };
@@ -733,8 +733,8 @@
 		53FE312B1F07C594003AA6A7 /* JGSwitchTableCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JGSwitchTableCell.swift; sourceTree = "<group>"; };
 		53FE312C1F07C594003AA6A7 /* JGTextTableCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JGTextTableCell.swift; sourceTree = "<group>"; };
 		7D0032141FD1988A009EAAFE /* SearchLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchLoader.swift; sourceTree = "<group>"; };
-		7D6B0F551FCE2F0600BC4050 /* UpdatePlaylistLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePlaylistLoader.swift; sourceTree = "<group>"; };
 		7D0032161FD2158E009EAAFE /* RandomSongsLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomSongsLoader.swift; sourceTree = "<group>"; };
+		7D6B0F551FCE2F0600BC4050 /* UpdatePlaylistLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePlaylistLoader.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1676,7 +1676,7 @@
 				ORGANIZATIONNAME = "Ben Baron";
 				TargetAttributes = {
 					53BC269F139AF0DD00A825F1 = {
-						DevelopmentTeam = 7596YH3S97;
+						DevelopmentTeam = 8Z527XYLA9;
 						LastSwiftMigration = 0900;
 						ProvisioningStyle = Automatic;
 					};
@@ -2165,6 +2165,7 @@
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				DEVELOPMENT_TEAM = 8Z527XYLA9;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2196,7 +2197,7 @@
 				);
 				OTHER_SWIFT_FLAGS = "-D BetaTarget $(inherited)";
 				PRECOMPS_INCLUDE_HEADERS_FROM_BUILT_PRODUCTS_DIR = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = com.einsteinx2.isubbetarewrite;
+				PRODUCT_BUNDLE_IDENTIFIER = net.lannysport.isub;
 				PRODUCT_NAME = "iSub Beta";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 4.0;
@@ -2215,6 +2216,7 @@
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				DEVELOPMENT_TEAM = 8Z527XYLA9;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2246,7 +2248,7 @@
 				);
 				OTHER_SWIFT_FLAGS = "-D BetaTarget $(inherited)";
 				PRECOMPS_INCLUDE_HEADERS_FROM_BUILT_PRODUCTS_DIR = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = com.einsteinx2.isubbetarewrite;
+				PRODUCT_BUNDLE_IDENTIFIER = net.lannysport.isub;
 				PRODUCT_NAME = "iSub Beta";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 4.0;
@@ -2265,6 +2267,7 @@
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				DEVELOPMENT_TEAM = 8Z527XYLA9;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2294,7 +2297,7 @@
 				);
 				OTHER_SWIFT_FLAGS = "-D BetaTarget $(inherited)";
 				PRECOMPS_INCLUDE_HEADERS_FROM_BUILT_PRODUCTS_DIR = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = com.einsteinx2.isubbetarewrite;
+				PRODUCT_BUNDLE_IDENTIFIER = net.lannysport.isub;
 				PRODUCT_NAME = "iSub Beta";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 4.0;


### PR DESCRIPTION
Allows for support of older subsonic servers and other servers implementing the subsonic protocol but which can't support the 5.3+ auth method because it requires access to plaintext passwords. E.g. Ampache.